### PR TITLE
[modify] Fix bug when name is shorter than 4 Chinese characters

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -20,7 +20,7 @@ refreshGap=3s
 getStock()
 {
  target=${sinaurl}""$1
- result=$result$'\n'`curl ${target} 2>/dev/null | iconv -f gb2312 -t utf-8 | sed "s/var //"`
+ result=$result$'\n'`curl ${target} 2>/dev/null | iconv -f gb2312 -t utf-8 | sed "s/var //" | sed "s/ /_/g"`
 }
 
 # for each code in $codes, -> getStock


### PR DESCRIPTION
For example, `金 融 街` has 3 Chinese characters and 2 space characters in it, the space will cause error when running `start.sh`. Otherwise `上证指数` has 4 Chinese characters and no space characters in it.
